### PR TITLE
Changes needed to compile docs

### DIFF
--- a/doc/gsp-sample.tex
+++ b/doc/gsp-sample.tex
@@ -252,7 +252,7 @@
 % space between two ascending punctum inclinatum glyphs in an descent
 \grechangedim{ascendingpunctuminclinatumdescendingshift}{-0.07918 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
 % Space after after a non-punctum inclinatum and before the upright punctum inclinatum
-\grechangedim{unisonpunctuminclinatumshift}{0.05286 cm plus 0.00728 cm minus 0.00455 cm}{scalable}%
+\grechangedim{uprightpunctuminclinatumshift}{0.05286 cm plus 0.00728 cm minus 0.00455 cm}{scalable}%
 
 %
 %%%%%%%%

--- a/tex/gregoriotex-gsp-default.tex
+++ b/tex/gregoriotex-gsp-default.tex
@@ -211,7 +211,7 @@
 % space between two ascending punctum inclinatum glyphs in an descent
 \gre@createdim{ascendingpunctuminclinatumdescendingshift}{-0.07918 cm plus 0.0009 cm minus 0.0009 cm}{scalable}%
 % space between two unison punctum inclinatum glyphs (at the unison)
-\gre@createdim{unisonpunctuminclinatumshift}{0.05286 cm plus 0.00728 cm minus 0.00455 cm}{scalable}%
+\gre@createdim{uprightpunctuminclinatumshift}{0.05286 cm plus 0.00728 cm minus 0.00455 cm}{scalable}%
 
 %
 %%%%%%%%


### PR DESCRIPTION
This accounts for the renaming of unisonpunctuminclinatumshift -> uprightpunctuminclinatumshift on the ctan branch.
This change was not picked up by the merges because of the change of file structure on the develop branch (gsp-default.tex -> gregoriotex-gsp-default.tex).